### PR TITLE
(feat) improve type definition to use createClient direcly

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,8 @@
 import {
+  MicroCMSListContent,
+  MicroCMSObjectContent,
   MicroCMSListResponse,
   MicroCMSQueries,
-  MicroCMSClient,
   WriteApiRequestResult as _WriteApiRequestResult,
   GetListDetailRequest as _GetListDetailRequest,
   GetListRequest as _GetListRequest,
@@ -20,93 +21,122 @@ export type ClientEndPoints = {
   };
 };
 
+type ResolveContentType<
+  T extends ClientEndPoints,
+  I extends keyof ClientEndPoints,
+  R extends { endpoint: keyof T[I] },
+  C = T[I][R['endpoint']] & (I extends 'list' ? MicroCMSListContent : MicroCMSObjectContent)
+> = R extends {
+  queries: {
+    fields: (infer F extends keyof C)[];
+  };
+}
+  ? Pick<C, F>
+  : T;
+
 /** getListDetail queries type */
-export type GetListDetailQueries<F> = {
-  fields?: F[];
-} & Omit<MicroCMSQueries, 'fields' | 'limit' | 'offset' | 'orders' | 'q' | 'ids' | 'filters'>;
+export interface GetListDetailQueries<E>
+  extends Omit<
+    MicroCMSQueries,
+    'fields' | 'limit' | 'offset' | 'orders' | 'q' | 'ids' | 'filters'
+  > {
+  fields?: Extract<keyof E | keyof MicroCMSListContent, string>[];
+}
 
 /** getListDetail request type */
-export type GetListDetailRequest<
-  T extends ClientEndPoints,
-  E extends keyof T['list'],
-  C extends T['list'][E],
-  F extends keyof C
-> = {
-  endpoint: E;
-  queries?: GetListDetailQueries<F>;
-} & Omit<_GetListDetailRequest, 'endpoint' | 'queries'>;
+export interface GetListDetailRequest<T extends ClientEndPoints> extends _GetListDetailRequest {
+  endpoint: Extract<keyof T['list'], string>;
+  queries?: GetListDetailQueries<T['list'][this['endpoint']]>;
+}
 
 /** getListDetail response type */
-export type GetListDetailResponse<C, F extends keyof C> = Pick<C, F>;
+export type GetListDetailResponse<
+  T extends ClientEndPoints,
+  R extends GetListDetailRequest<T>
+> = ResolveContentType<T, 'list', R>;
 
 /** getList queries type */
-export type GetListQueries<F> = {
-  fields?: F[];
-} & Omit<MicroCMSQueries, 'fields'>;
+export interface GetListQueries<E> extends MicroCMSQueries {
+  fields?: Extract<keyof E | keyof MicroCMSListContent, string>[];
+}
 
 /** getList request type */
-export type GetListRequest<
-  T extends ClientEndPoints,
-  E extends keyof T['list'],
-  C extends T['list'][E],
-  F extends keyof C
-> = {
-  endpoint: E;
-  queries?: GetListQueries<F>;
-} & Omit<_GetListRequest, 'endpoint' | 'queries'>;
+export interface GetListRequest<T extends ClientEndPoints> extends _GetListRequest {
+  endpoint: Extract<keyof T['list'], string>;
+  queries?: GetListQueries<T['list'][this['endpoint']]>;
+}
 
 /** getList response type */
-export type GetListResponse<C, F extends keyof C> = {
-  contents: Pick<C, F>[];
-  totalCount: number;
-  offset: number;
-  limit: number;
-} & Omit<MicroCMSListResponse<C>, 'contents'>;
+export interface GetListResponse<T extends ClientEndPoints, R extends GetListRequest<T>>
+  extends MicroCMSListResponse<unknown> {
+  contents: (ResolveContentType<T, 'list', R> & MicroCMSListContent)[];
+}
 
 /** getObject queries type */
-export type GetObjectQueries<F> = {
-  fields?: F[];
-} & Omit<MicroCMSQueries, 'fields' | 'limit' | 'offset' | 'orders' | 'q' | 'ids' | 'filters'>;
+export interface GetObjectQueries<E>
+  extends Omit<
+    MicroCMSQueries,
+    'fields' | 'limit' | 'offset' | 'orders' | 'q' | 'ids' | 'filters'
+  > {
+  fields?: Extract<keyof E | keyof MicroCMSObjectContent, string>[];
+}
 
-/** getObject request type */
-export type GetObjectRequest<
-  T extends ClientEndPoints,
-  E extends keyof T['object'],
-  C extends T['object'][E],
-  F extends keyof C
-> = {
-  endpoint: E;
-  queries?: GetObjectQueries<F>;
-} & Omit<_GetObjectRequest, 'endpoint' | 'queries'>;
+/** getObject queries type */
+export interface GetObjectRequest<T extends ClientEndPoints> extends _GetObjectRequest {
+  endpoint: Extract<keyof T['object'], string>;
+  queries?: GetObjectQueries<T['object'][this['endpoint']]>;
+}
 
 /** getObject response type */
-export type GetListObjectResponse<C, F extends keyof C> = Pick<C, F>;
+export type GetListObjectResponse<
+  T extends ClientEndPoints,
+  R extends GetObjectRequest<T>
+> = ResolveContentType<T, 'object', R>;
 
 /** create and update result type */
 export type WriteApiRequestResult = _WriteApiRequestResult;
 
 /** create request type */
-export type CreateRequest<E, C> = {
-  endpoint: E;
-} & Omit<_CreateRequest<C>, 'endpoint'>;
+export interface CreateRequest<T extends ClientEndPoints>
+  extends _CreateRequest<Record<string, any>> {
+  endpoint: Extract<keyof T['list'] | keyof T['object'], string>;
+  content: (T['list'] & T['object'])[this['endpoint']] & Record<string, any>;
+}
+
+interface UpdateListRequest<T extends ClientEndPoints> extends _UpdateRequest<unknown> {
+  endpoint: Extract<keyof T['list'], string>;
+  contentId: string;
+  content: Partial<T['list'][this['endpoint']]>;
+}
+
+interface UpdateObjectRequest<T extends ClientEndPoints> extends _UpdateRequest<unknown> {
+  endpoint: Extract<keyof T['object'], string>;
+  content: Partial<T['object'][this['endpoint']]>;
+}
 
 /** update request type */
-export type UpdateRequest<
-  T extends ClientEndPoints,
-  LE extends keyof T['list'],
-  OE extends keyof T['object']
-> =
-  | ({
-      endpoint: LE;
-      contentId: string;
-    } & Omit<_UpdateRequest<T['list'][OE]>, 'endpoint' | 'contentId'>)
-  | ({
-      endpoint: OE;
-    } & Omit<_UpdateRequest<T['object'][OE]>, 'endpoint' | 'contentId'>);
+export type UpdateRequest<T extends ClientEndPoints> =
+  | UpdateListRequest<T>
+  | UpdateObjectRequest<T>;
 
 /** delete request type */
-export type DeleteRequest<E> = {
-  endpoint: E;
-} & Omit<_DeleteRequest, 'endpoint'>;
+export interface DeleteRequest<T extends ClientEndPoints> extends _DeleteRequest {
+  endpoint: Extract<keyof T['list'] | keyof T['object'], string>;
+}
+
+interface MicroCMSClient<T extends ClientEndPoints> {
+  getListDetail<R extends GetListDetailRequest<T>>(
+    request: R
+  ): Promise<GetListDetailResponse<T, R>>;
+  getList<R extends GetListRequest<T>>(request: R): Promise<GetListResponse<T, R>>;
+  getObject<R extends GetObjectRequest<T>>(request: R): Promise<GetListObjectResponse<T, R>>;
+  create<R extends CreateRequest<T>>(request: R): Promise<WriteApiRequestResult>;
+  update<R extends UpdateRequest<T>>(request: R): Promise<WriteApiRequestResult>;
+  delete<R extends DeleteRequest<T>>(request: R): Promise<void>;
+}
+
+export interface ExtendedMicroCMSClient<T extends ClientEndPoints> extends MicroCMSClient<T> {
+  getAll<R extends GetListRequest<T>>(request: R): Promise<GetListResponse<T, R>>;
+}
 
 export { MicroCMSClient };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,8 +1,0 @@
-import { MicroCMSQueries } from 'microcms-js-sdk';
-import { GetListQueries, GetListDetailQueries, GetObjectQueries } from './types';
-
-export const queryParser = <T>(
-  queries: GetListDetailQueries<T> | GetListQueries<T> | GetObjectQueries<T>
-): MicroCMSQueries => {
-  return { ...queries, fields: queries.fields?.map((v) => String(v)) };
-};


### PR DESCRIPTION
Now that no modification needs to be applied to createClient from 'microcms-js-sdk', we can alternatively use this library like:
```ts
import { createClient } from 'microcms-js-sdk';
import { MicroCMSClient } from 'microcms-ts-sdk';

type Endpoints = {
  // definition
};

const client: MicroCMSClient<Endpoints> = createClient({
  serviceDomain: '',
  apiKey: ''
});
```