### PR TITLE
Release/0.2.0

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,6 +14,14 @@ module.exports = {
   rules: {
     'prettier/prettier': ['error'],
     semi: ['off'],
-    indent: ['off']
+    indent: ['off'],
+    'space-before-function-paren': [
+      'error',
+      {
+        anonymous: 'always',
+        named: 'never',
+        asyncArrow: 'always'
+      }
+    ]
   }
 };

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ const client = createClient<Endpoints>({
 ```
 
 It is also possible to use only type definitions for the original client.
+(Unsupported `getAll` method)
 
 ```ts
 import { createClient } from 'microcms-js-sdk';
@@ -117,6 +118,15 @@ client.getList({
   queries: {
     fields: ['id', 'text', 'publishedAt'] // (keyof (Content & MicroCMSListContent))[]
   }
+});
+```
+
+Support for all acquisitions.
+
+```ts
+/** Get all contents for endpoint */
+client.getAll({
+  endpoint: 'contents'
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -20,13 +20,13 @@ yarn add microcms-ts-sdk
 ### How to use
 
 Supported of "microcms-js-sdk".<br />
-Please read the instructions on how to use the support destination.
-
-https://github.com/microcmsio/microcms-js-sdk#how-to-use
+For more information on how to use this service, please click [here](https://github.com/microcmsio/microcms-js-sdk#how-to-use).
 
 ### Type safe usage
 
 ```ts
+import { createClient } from 'microcms-ts-sdk';
+
 // Type definition
 type Content = {
   text: string;
@@ -46,6 +46,22 @@ interface Endpoints {
 // Initialize Client SDK.
 const client = createClient<Endpoints>({
   serviceDomain: 'YOUR_DOMAIN', // YOUR_DOMAIN is the XXXX part of XXXX.microcms.io
+  apiKey: 'YOUR_API_KEY'
+});
+```
+
+It is also possible to use only type definitions for the original client.
+
+```ts
+import { createClient } from 'microcms-js-sdk';
+import { MicroCMSClient } from 'microcms-ts-sdk';
+
+type Endpoints = {
+  // definition
+};
+
+const client: MicroCMSClient<Endpoints> = createClient({
+  serviceDomain: 'YOUR_DOMAIN',
   apiKey: 'YOUR_API_KEY'
 });
 ```

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "eslint-plugin-promise": "^6.1.1",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.7.1",
-    "typescript": "^4.9.3"
+    "typescript": "^4.8.4"
   },
   "author": "hanetsuki<me@tsuki-lab.net>",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "microcms-ts-sdk",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "wrapper for \"microcms-js-sdk\". More type-safe.",
   "main": "./dist/index.cjs.js",
   "module": "./dist/index.esm.js",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,14 +13,14 @@ specifiers:
   microcms-js-sdk: ^2.3.2
   npm-run-all: ^4.1.5
   prettier: ^2.7.1
-  typescript: ^4.9.3
+  typescript: ^4.8.4
 
 dependencies:
   microcms-js-sdk: 2.3.2
 
 devDependencies:
-  '@typescript-eslint/eslint-plugin': 5.43.0_nqj4bdx4ekws7aecttskpih4py
-  '@typescript-eslint/parser': 5.43.0_hsf322ms6xhhd4b5ne6lb74y4a
+  '@typescript-eslint/eslint-plugin': 5.43.0_ol5heeoi7wmwb4tenztnb7jlze
+  '@typescript-eslint/parser': 5.43.0_zksrc6ykdxhogxjbhb5axiabwi
   esbuild: 0.15.14
   eslint: 8.28.0
   eslint-config-standard: 17.0.0_5dakk4wnrkkieagghiqvu5yn4y
@@ -30,7 +30,7 @@ devDependencies:
   eslint-plugin-promise: 6.1.1_eslint@8.28.0
   npm-run-all: 4.1.5
   prettier: 2.7.1
-  typescript: 4.9.3
+  typescript: 4.8.4
 
 packages:
 
@@ -122,7 +122,7 @@ packages:
     resolution: {integrity: sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==}
     dev: true
 
-  /@typescript-eslint/eslint-plugin/5.43.0_nqj4bdx4ekws7aecttskpih4py:
+  /@typescript-eslint/eslint-plugin/5.43.0_ol5heeoi7wmwb4tenztnb7jlze:
     resolution: {integrity: sha512-wNPzG+eDR6+hhW4yobEmpR36jrqqQv1vxBq5LJO3fBAktjkvekfr4BRl+3Fn1CM/A+s8/EiGUbOMDoYqWdbtXA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -133,23 +133,23 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.43.0_hsf322ms6xhhd4b5ne6lb74y4a
+      '@typescript-eslint/parser': 5.43.0_zksrc6ykdxhogxjbhb5axiabwi
       '@typescript-eslint/scope-manager': 5.43.0
-      '@typescript-eslint/type-utils': 5.43.0_hsf322ms6xhhd4b5ne6lb74y4a
-      '@typescript-eslint/utils': 5.43.0_hsf322ms6xhhd4b5ne6lb74y4a
+      '@typescript-eslint/type-utils': 5.43.0_zksrc6ykdxhogxjbhb5axiabwi
+      '@typescript-eslint/utils': 5.43.0_zksrc6ykdxhogxjbhb5axiabwi
       debug: 4.3.4
       eslint: 8.28.0
       ignore: 5.2.0
       natural-compare-lite: 1.4.0
       regexpp: 3.2.0
       semver: 7.3.8
-      tsutils: 3.21.0_typescript@4.9.3
-      typescript: 4.9.3
+      tsutils: 3.21.0_typescript@4.8.4
+      typescript: 4.8.4
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser/5.43.0_hsf322ms6xhhd4b5ne6lb74y4a:
+  /@typescript-eslint/parser/5.43.0_zksrc6ykdxhogxjbhb5axiabwi:
     resolution: {integrity: sha512-2iHUK2Lh7PwNUlhFxxLI2haSDNyXvebBO9izhjhMoDC+S3XI9qt2DGFUsiJ89m2k7gGYch2aEpYqV5F/+nwZug==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -161,10 +161,10 @@ packages:
     dependencies:
       '@typescript-eslint/scope-manager': 5.43.0
       '@typescript-eslint/types': 5.43.0
-      '@typescript-eslint/typescript-estree': 5.43.0_typescript@4.9.3
+      '@typescript-eslint/typescript-estree': 5.43.0_typescript@4.8.4
       debug: 4.3.4
       eslint: 8.28.0
-      typescript: 4.9.3
+      typescript: 4.8.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -177,7 +177,7 @@ packages:
       '@typescript-eslint/visitor-keys': 5.43.0
     dev: true
 
-  /@typescript-eslint/type-utils/5.43.0_hsf322ms6xhhd4b5ne6lb74y4a:
+  /@typescript-eslint/type-utils/5.43.0_zksrc6ykdxhogxjbhb5axiabwi:
     resolution: {integrity: sha512-K21f+KY2/VvYggLf5Pk4tgBOPs2otTaIHy2zjclo7UZGLyFH86VfUOm5iq+OtDtxq/Zwu2I3ujDBykVW4Xtmtg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -187,12 +187,12 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/typescript-estree': 5.43.0_typescript@4.9.3
-      '@typescript-eslint/utils': 5.43.0_hsf322ms6xhhd4b5ne6lb74y4a
+      '@typescript-eslint/typescript-estree': 5.43.0_typescript@4.8.4
+      '@typescript-eslint/utils': 5.43.0_zksrc6ykdxhogxjbhb5axiabwi
       debug: 4.3.4
       eslint: 8.28.0
-      tsutils: 3.21.0_typescript@4.9.3
-      typescript: 4.9.3
+      tsutils: 3.21.0_typescript@4.8.4
+      typescript: 4.8.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -202,7 +202,7 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
-  /@typescript-eslint/typescript-estree/5.43.0_typescript@4.9.3:
+  /@typescript-eslint/typescript-estree/5.43.0_typescript@4.8.4:
     resolution: {integrity: sha512-BZ1WVe+QQ+igWal2tDbNg1j2HWUkAa+CVqdU79L4HP9izQY6CNhXfkNwd1SS4+sSZAP/EthI1uiCSY/+H0pROg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -217,13 +217,13 @@ packages:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.3.8
-      tsutils: 3.21.0_typescript@4.9.3
-      typescript: 4.9.3
+      tsutils: 3.21.0_typescript@4.8.4
+      typescript: 4.8.4
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/utils/5.43.0_hsf322ms6xhhd4b5ne6lb74y4a:
+  /@typescript-eslint/utils/5.43.0_zksrc6ykdxhogxjbhb5axiabwi:
     resolution: {integrity: sha512-8nVpA6yX0sCjf7v/NDfeaOlyaIIqL7OaIGOWSPFqUKK59Gnumd3Wa+2l8oAaYO2lk0sO+SbWFWRSvhu8gLGv4A==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -233,7 +233,7 @@ packages:
       '@types/semver': 7.3.13
       '@typescript-eslint/scope-manager': 5.43.0
       '@typescript-eslint/types': 5.43.0
-      '@typescript-eslint/typescript-estree': 5.43.0_typescript@4.9.3
+      '@typescript-eslint/typescript-estree': 5.43.0_typescript@4.8.4
       eslint: 8.28.0
       eslint-scope: 5.1.1
       eslint-utils: 3.0.0_eslint@8.28.0
@@ -810,7 +810,7 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.43.0_hsf322ms6xhhd4b5ne6lb74y4a
+      '@typescript-eslint/parser': 5.43.0_zksrc6ykdxhogxjbhb5axiabwi
       debug: 3.2.7
       eslint: 8.28.0
       eslint-import-resolver-node: 0.3.6
@@ -839,7 +839,7 @@ packages:
       '@typescript-eslint/parser':
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.43.0_hsf322ms6xhhd4b5ne6lb74y4a
+      '@typescript-eslint/parser': 5.43.0_zksrc6ykdxhogxjbhb5axiabwi
       array-includes: 3.1.6
       array.prototype.flat: 1.3.1
       debug: 2.6.9
@@ -1929,14 +1929,14 @@ packages:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
     dev: true
 
-  /tsutils/3.21.0_typescript@4.9.3:
+  /tsutils/3.21.0_typescript@4.8.4:
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
     engines: {node: '>= 6'}
     peerDependencies:
       typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
     dependencies:
       tslib: 1.14.1
-      typescript: 4.9.3
+      typescript: 4.8.4
     dev: true
 
   /type-check/0.4.0:
@@ -1951,8 +1951,8 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  /typescript/4.9.3:
-    resolution: {integrity: sha512-CIfGzTelbKNEnLpLdGFgdyKhG23CKdKgQPOBc+OUNrkJ2vr+KSzsSV5kq5iWhEQbok+quxgGzrAtGWCyU7tHnA==}
+  /typescript/4.8.4:
+    resolution: {integrity: sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==}
     engines: {node: '>=4.2.0'}
     hasBin: true
     dev: true

--- a/sample/used-microcms-ts-client.ts
+++ b/sample/used-microcms-ts-client.ts
@@ -4,18 +4,18 @@ type Content = {
   text: string;
 };
 
-interface Endpoints {
+type Endpoints = {
   list: {
     contents: Content;
   };
   object: {
     content: Content;
   };
-}
+};
 
 const client = createClient<Endpoints>({
-  serviceDomain: '',
-  apiKey: ''
+  serviceDomain: 'YOUR_DOMAIN',
+  apiKey: 'YOUR_API_KEY'
 });
 
 client
@@ -35,7 +35,7 @@ client
       fields: ['id', 'text', 'publishedAt']
     }
   })
-  .then((res) => res);
+  .then((res) => res.contents[0]);
 
 client
   .getAll({

--- a/sample/used-origin-client.ts
+++ b/sample/used-origin-client.ts
@@ -1,0 +1,29 @@
+import { createClient } from 'microcms-js-sdk';
+import { MicroCMSClient } from '../src';
+
+type Content = {
+  text: string;
+};
+
+type Endpoints = {
+  list: {
+    contents: Content;
+  };
+  object: {
+    content: Content;
+  };
+};
+
+const client: MicroCMSClient<Endpoints> = createClient({
+  serviceDomain: 'YOUR_DOMAIN',
+  apiKey: 'YOUR_API_KEY'
+});
+
+client
+  .getList({
+    endpoint: 'contents',
+    queries: {
+      fields: ['id', 'text', 'publishedAt']
+    }
+  })
+  .then((res) => res.contents[0]);

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,14 +1,21 @@
-import { createClient as _createClient, MicroCMSClient } from 'microcms-js-sdk';
-import { ClientEndPoints, ExtendedMicroCMSClient, GetListRequest, GetListResponse } from './types';
+import {
+  createClient as createClientOrigin,
+  MicroCMSClient as MicroCMSClientParams
+} from 'microcms-js-sdk';
+import {
+  ClientEndPoints,
+  MicroCMSTsClient,
+  MicroCMSGetListRequest,
+  MicroCMSGetListResponse
+} from './types';
 
 export const createClient = <T extends ClientEndPoints>(
-  clientArg: MicroCMSClient
-): ExtendedMicroCMSClient<T> => ({
-  ..._createClient(clientArg),
-  // eslint-disable-next-line space-before-function-paren
-  async getAll<R extends GetListRequest<T>>(request: R) {
-    const LIMIT = 1;
-    const handler = async (offset = 0, limit = LIMIT): Promise<GetListResponse<T, R>> => {
+  clientArg: MicroCMSClientParams
+): MicroCMSTsClient<T> => ({
+  ...createClientOrigin(clientArg),
+  getAll<R extends MicroCMSGetListRequest<T>>(request: R) {
+    const LIMIT = 1000;
+    const handler = async (offset = 0, limit = LIMIT): Promise<MicroCMSGetListResponse<T, R>> => {
       const data = await this.getList<R>(
         Object.assign({}, request, {
           queries: Object.assign({}, request.queries, { offset, limit })

--- a/src/types.ts
+++ b/src/types.ts
@@ -68,8 +68,8 @@ export interface GetListRequest<T extends ClientEndPoints> extends _GetListReque
 
 /** getList response type */
 export interface GetListResponse<T extends ClientEndPoints, R extends GetListRequest<T>>
-  extends MicroCMSListResponse<unknown> {
-  contents: (ResolveContentType<T, 'list', R> & MicroCMSListContent)[];
+  extends Omit<MicroCMSListResponse<unknown>, 'contents'> {
+  contents: ResolveContentType<T, 'list', R>[];
 }
 
 /** getObject queries type */

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,7 +35,7 @@ type ResolveContentType<
   : T;
 
 /** getListDetail queries type */
-export interface GetListDetailQueries<E>
+export interface MicroCMSGetListDetailQueries<E>
   extends Omit<
     MicroCMSQueries,
     'fields' | 'limit' | 'offset' | 'orders' | 'q' | 'ids' | 'filters'
@@ -44,36 +44,39 @@ export interface GetListDetailQueries<E>
 }
 
 /** getListDetail request type */
-export interface GetListDetailRequest<T extends ClientEndPoints> extends _GetListDetailRequest {
+export interface MicroCMSGetListDetailRequest<T extends ClientEndPoints>
+  extends _GetListDetailRequest {
   endpoint: Extract<keyof T['list'], string>;
-  queries?: GetListDetailQueries<T['list'][this['endpoint']]>;
+  queries?: MicroCMSGetListDetailQueries<T['list'][this['endpoint']]>;
 }
 
 /** getListDetail response type */
-export type GetListDetailResponse<
+export type MicroCMSGetListDetailResponse<
   T extends ClientEndPoints,
-  R extends GetListDetailRequest<T>
+  R extends MicroCMSGetListDetailRequest<T>
 > = ResolveContentType<T, 'list', R>;
 
 /** getList queries type */
-export interface GetListQueries<E> extends MicroCMSQueries {
+export interface MicroCMSGetListQueries<E> extends MicroCMSQueries {
   fields?: Extract<keyof E | keyof MicroCMSListContent, string>[];
 }
 
 /** getList request type */
-export interface GetListRequest<T extends ClientEndPoints> extends _GetListRequest {
+export interface MicroCMSGetListRequest<T extends ClientEndPoints> extends _GetListRequest {
   endpoint: Extract<keyof T['list'], string>;
-  queries?: GetListQueries<T['list'][this['endpoint']]>;
+  queries?: MicroCMSGetListQueries<T['list'][this['endpoint']]>;
 }
 
 /** getList response type */
-export interface GetListResponse<T extends ClientEndPoints, R extends GetListRequest<T>>
-  extends Omit<MicroCMSListResponse<unknown>, 'contents'> {
+export interface MicroCMSGetListResponse<
+  T extends ClientEndPoints,
+  R extends MicroCMSGetListRequest<T>
+> extends Omit<MicroCMSListResponse<unknown>, 'contents'> {
   contents: ResolveContentType<T, 'list', R>[];
 }
 
 /** getObject queries type */
-export interface GetObjectQueries<E>
+export interface MicroCMSGetObjectQueries<E>
   extends Omit<
     MicroCMSQueries,
     'fields' | 'limit' | 'offset' | 'orders' | 'q' | 'ids' | 'filters'
@@ -82,15 +85,15 @@ export interface GetObjectQueries<E>
 }
 
 /** getObject queries type */
-export interface GetObjectRequest<T extends ClientEndPoints> extends _GetObjectRequest {
+export interface MicroCMSGetObjectRequest<T extends ClientEndPoints> extends _GetObjectRequest {
   endpoint: Extract<keyof T['object'], string>;
-  queries?: GetObjectQueries<T['object'][this['endpoint']]>;
+  queries?: MicroCMSGetObjectQueries<T['object'][this['endpoint']]>;
 }
 
 /** getObject response type */
-export type GetListObjectResponse<
+export type MicroCMSGetListObjectResponse<
   T extends ClientEndPoints,
-  R extends GetObjectRequest<T>
+  R extends MicroCMSGetObjectRequest<T>
 > = ResolveContentType<T, 'object', R>;
 
 /** create and update result type */
@@ -103,13 +106,13 @@ export interface CreateRequest<T extends ClientEndPoints>
   content: (T['list'] & T['object'])[this['endpoint']] & Record<string, any>;
 }
 
-interface UpdateListRequest<T extends ClientEndPoints> extends _UpdateRequest<unknown> {
+export interface UpdateListRequest<T extends ClientEndPoints> extends _UpdateRequest<unknown> {
   endpoint: Extract<keyof T['list'], string>;
   contentId: string;
   content: Partial<T['list'][this['endpoint']]>;
 }
 
-interface UpdateObjectRequest<T extends ClientEndPoints> extends _UpdateRequest<unknown> {
+export interface UpdateObjectRequest<T extends ClientEndPoints> extends _UpdateRequest<unknown> {
   endpoint: Extract<keyof T['object'], string>;
   content: Partial<T['object'][this['endpoint']]>;
 }
@@ -124,19 +127,19 @@ export interface DeleteRequest<T extends ClientEndPoints> extends _DeleteRequest
   endpoint: Extract<keyof T['list'] | keyof T['object'], string>;
 }
 
-interface MicroCMSClient<T extends ClientEndPoints> {
-  getListDetail<R extends GetListDetailRequest<T>>(
+export interface MicroCMSClient<T extends ClientEndPoints> {
+  getListDetail<R extends MicroCMSGetListDetailRequest<T>>(
     request: R
-  ): Promise<GetListDetailResponse<T, R>>;
-  getList<R extends GetListRequest<T>>(request: R): Promise<GetListResponse<T, R>>;
-  getObject<R extends GetObjectRequest<T>>(request: R): Promise<GetListObjectResponse<T, R>>;
+  ): Promise<MicroCMSGetListDetailResponse<T, R>>;
+  getList<R extends MicroCMSGetListRequest<T>>(request: R): Promise<MicroCMSGetListResponse<T, R>>;
+  getObject<R extends MicroCMSGetObjectRequest<T>>(
+    request: R
+  ): Promise<MicroCMSGetListObjectResponse<T, R>>;
   create<R extends CreateRequest<T>>(request: R): Promise<WriteApiRequestResult>;
   update<R extends UpdateRequest<T>>(request: R): Promise<WriteApiRequestResult>;
   delete<R extends DeleteRequest<T>>(request: R): Promise<void>;
 }
 
-export interface ExtendedMicroCMSClient<T extends ClientEndPoints> extends MicroCMSClient<T> {
-  getAll<R extends GetListRequest<T>>(request: R): Promise<GetListResponse<T, R>>;
+export interface MicroCMSTsClient<T extends ClientEndPoints> extends MicroCMSClient<T> {
+  getAll<R extends MicroCMSGetListRequest<T>>(request: R): Promise<MicroCMSGetListResponse<T, R>>;
 }
-
-export { MicroCMSClient };

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,8 @@
 import {
+  MicroCMSListContent,
+  MicroCMSObjectContent,
   MicroCMSListResponse,
   MicroCMSQueries,
-  MicroCMSClient,
   WriteApiRequestResult as _WriteApiRequestResult,
   GetListDetailRequest as _GetListDetailRequest,
   GetListRequest as _GetListRequest,
@@ -20,93 +21,122 @@ export type ClientEndPoints = {
   };
 };
 
+type ResolveContentType<
+  T extends ClientEndPoints,
+  I extends keyof ClientEndPoints,
+  R extends { endpoint: keyof T[I] },
+  C = T[I][R['endpoint']] & (I extends 'list' ? MicroCMSListContent : MicroCMSObjectContent)
+> = R extends {
+  queries: {
+    fields: (infer F extends keyof C)[];
+  };
+}
+  ? Pick<C, F>
+  : T;
+
 /** getListDetail queries type */
-export type GetListDetailQueries<F> = {
-  fields?: F[];
-} & Omit<MicroCMSQueries, 'fields' | 'limit' | 'offset' | 'orders' | 'q' | 'ids' | 'filters'>;
+export interface GetListDetailQueries<E>
+  extends Omit<
+    MicroCMSQueries,
+    'fields' | 'limit' | 'offset' | 'orders' | 'q' | 'ids' | 'filters'
+  > {
+  fields?: Extract<keyof E | keyof MicroCMSListContent, string>[];
+}
 
 /** getListDetail request type */
-export type GetListDetailRequest<
-  T extends ClientEndPoints,
-  E extends keyof T['list'],
-  C extends T['list'][E],
-  F extends keyof C
-> = {
-  endpoint: E;
-  queries?: GetListDetailQueries<F>;
-} & Omit<_GetListDetailRequest, 'endpoint' | 'queries'>;
+export interface GetListDetailRequest<T extends ClientEndPoints> extends _GetListDetailRequest {
+  endpoint: Extract<keyof T['list'], string>;
+  queries?: GetListDetailQueries<T['list'][this['endpoint']]>;
+}
 
 /** getListDetail response type */
-export type GetListDetailResponse<C, F extends keyof C> = Pick<C, F>;
+export type GetListDetailResponse<
+  T extends ClientEndPoints,
+  R extends GetListDetailRequest<T>
+> = ResolveContentType<T, 'list', R>;
 
 /** getList queries type */
-export type GetListQueries<F> = {
-  fields?: F[];
-} & Omit<MicroCMSQueries, 'fields'>;
+export interface GetListQueries<E> extends MicroCMSQueries {
+  fields?: Extract<keyof E | keyof MicroCMSListContent, string>[];
+}
 
 /** getList request type */
-export type GetListRequest<
-  T extends ClientEndPoints,
-  E extends keyof T['list'],
-  C extends T['list'][E],
-  F extends keyof C
-> = {
-  endpoint: E;
-  queries?: GetListQueries<F>;
-} & Omit<_GetListRequest, 'endpoint' | 'queries'>;
+export interface GetListRequest<T extends ClientEndPoints> extends _GetListRequest {
+  endpoint: Extract<keyof T['list'], string>;
+  queries?: GetListQueries<T['list'][this['endpoint']]>;
+}
 
 /** getList response type */
-export type GetListResponse<C, F extends keyof C> = {
-  contents: Pick<C, F>[];
-  totalCount: number;
-  offset: number;
-  limit: number;
-} & Omit<MicroCMSListResponse<C>, 'contents'>;
+export interface GetListResponse<T extends ClientEndPoints, R extends GetListRequest<T>>
+  extends MicroCMSListResponse<unknown> {
+  contents: (ResolveContentType<T, 'list', R> & MicroCMSListContent)[];
+}
 
 /** getObject queries type */
-export type GetObjectQueries<F> = {
-  fields?: F[];
-} & Omit<MicroCMSQueries, 'fields' | 'limit' | 'offset' | 'orders' | 'q' | 'ids' | 'filters'>;
+export interface GetObjectQueries<E>
+  extends Omit<
+    MicroCMSQueries,
+    'fields' | 'limit' | 'offset' | 'orders' | 'q' | 'ids' | 'filters'
+  > {
+  fields?: Extract<keyof E | keyof MicroCMSObjectContent, string>[];
+}
 
-/** getObject request type */
-export type GetObjectRequest<
-  T extends ClientEndPoints,
-  E extends keyof T['object'],
-  C extends T['object'][E],
-  F extends keyof C
-> = {
-  endpoint: E;
-  queries?: GetObjectQueries<F>;
-} & Omit<_GetObjectRequest, 'endpoint' | 'queries'>;
+/** getObject queries type */
+export interface GetObjectRequest<T extends ClientEndPoints> extends _GetObjectRequest {
+  endpoint: Extract<keyof T['object'], string>;
+  queries?: GetObjectQueries<T['object'][this['endpoint']]>;
+}
 
 /** getObject response type */
-export type GetListObjectResponse<C, F extends keyof C> = Pick<C, F>;
+export type GetListObjectResponse<
+  T extends ClientEndPoints,
+  R extends GetObjectRequest<T>
+> = ResolveContentType<T, 'object', R>;
 
 /** create and update result type */
 export type WriteApiRequestResult = _WriteApiRequestResult;
 
 /** create request type */
-export type CreateRequest<E, C> = {
-  endpoint: E;
-} & Omit<_CreateRequest<C>, 'endpoint'>;
+export interface CreateRequest<T extends ClientEndPoints>
+  extends _CreateRequest<Record<string, any>> {
+  endpoint: Extract<keyof T['list'] | keyof T['object'], string>;
+  content: (T['list'] & T['object'])[this['endpoint']] & Record<string, any>;
+}
+
+interface UpdateListRequest<T extends ClientEndPoints> extends _UpdateRequest<unknown> {
+  endpoint: Extract<keyof T['list'], string>;
+  contentId: string;
+  content: Partial<T['list'][this['endpoint']]>;
+}
+
+interface UpdateObjectRequest<T extends ClientEndPoints> extends _UpdateRequest<unknown> {
+  endpoint: Extract<keyof T['object'], string>;
+  content: Partial<T['object'][this['endpoint']]>;
+}
 
 /** update request type */
-export type UpdateRequest<
-  T extends ClientEndPoints,
-  LE extends keyof T['list'],
-  OE extends keyof T['object']
-> =
-  | ({
-      endpoint: LE;
-      contentId: string;
-    } & Omit<_UpdateRequest<T['list'][OE]>, 'endpoint' | 'contentId'>)
-  | ({
-      endpoint: OE;
-    } & Omit<_UpdateRequest<T['object'][OE]>, 'endpoint' | 'contentId'>);
+export type UpdateRequest<T extends ClientEndPoints> =
+  | UpdateListRequest<T>
+  | UpdateObjectRequest<T>;
 
 /** delete request type */
-export type DeleteRequest<E> = {
-  endpoint: E;
-} & Omit<_DeleteRequest, 'endpoint'>;
+export interface DeleteRequest<T extends ClientEndPoints> extends _DeleteRequest {
+  endpoint: Extract<keyof T['list'] | keyof T['object'], string>;
+}
+
+interface MicroCMSClient<T extends ClientEndPoints> {
+  getListDetail<R extends GetListDetailRequest<T>>(
+    request: R
+  ): Promise<GetListDetailResponse<T, R>>;
+  getList<R extends GetListRequest<T>>(request: R): Promise<GetListResponse<T, R>>;
+  getObject<R extends GetObjectRequest<T>>(request: R): Promise<GetListObjectResponse<T, R>>;
+  create<R extends CreateRequest<T>>(request: R): Promise<WriteApiRequestResult>;
+  update<R extends UpdateRequest<T>>(request: R): Promise<WriteApiRequestResult>;
+  delete<R extends DeleteRequest<T>>(request: R): Promise<void>;
+}
+
+export interface ExtendedMicroCMSClient<T extends ClientEndPoints> extends MicroCMSClient<T> {
+  getAll<R extends GetListRequest<T>>(request: R): Promise<GetListResponse<T, R>>;
+}
 
 export { MicroCMSClient };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,8 +1,0 @@
-import { MicroCMSQueries } from 'microcms-js-sdk';
-import { GetListQueries, GetListDetailQueries, GetObjectQueries } from './types';
-
-export const queryParser = <T>(
-  queries: GetListDetailQueries<T> | GetListQueries<T> | GetObjectQueries<T>
-): MicroCMSQueries => {
-  return { ...queries, fields: queries.fields?.map((v) => String(v)) };
-};


### PR DESCRIPTION
- #10 @cm-ayf
  - #11 @tsuki-lab 
- #12 @tsuki-lab 

# Changes

It is also possible to use only type definitions for the original client.
```ts
import { createClient } from 'microcms-js-sdk';
import { MicroCMSClient } from 'microcms-ts-sdk';

type Endpoints = {
  // definition
};

const client: MicroCMSClient<Endpoints> = createClient({
  serviceDomain: 'YOUR_DOMAIN',
  apiKey: 'YOUR_API_KEY'
});
```