### PR TITLE
Feature/microcms schema infer type

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ For more information on how to use this service, please click [here](https://git
 ### Type safe usage
 
 ```ts
-import { createClient } from 'microcms-ts-sdk';
+import { createClient, MicroCMSSchemaInfer } from 'microcms-ts-sdk';
 
 // Type definition
 type Content = {
@@ -48,6 +48,29 @@ const client = createClient<Endpoints>({
   serviceDomain: 'YOUR_DOMAIN', // YOUR_DOMAIN is the XXXX part of XXXX.microcms.io
   apiKey: 'YOUR_API_KEY'
 });
+
+// Schema type inference
+type Schema = MicroCMSSchemaInfer<typeof client>;
+/**
+ * Schema[contents]
+ * {
+ *   id: string;
+ *   createdAt: string;
+ *   updatedAt: string;
+ *   publishedAt?: string;
+ *   revisedAt?: string;
+ *   text: string;
+ * }
+ *
+ * Schema[content]
+ * {
+ *   createdAt: string;
+ *   updatedAt: string;
+ *   publishedAt?: string;
+ *   revisedAt?: string;
+ *   text: string;
+ * }
+ */
 ```
 
 It is also possible to use only type definitions for the original client.

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,7 @@ import {
   UpdateRequest as _UpdateRequest,
   DeleteRequest as _DeleteRequest
 } from 'microcms-js-sdk';
+import { createClient } from './client';
 
 export type ClientEndPoints = {
   list?: {
@@ -143,3 +144,16 @@ export interface MicroCMSClient<T extends ClientEndPoints> {
 export interface MicroCMSTsClient<T extends ClientEndPoints> extends MicroCMSClient<T> {
   getAll<R extends MicroCMSGetListRequest<T>>(request: R): Promise<MicroCMSGetListResponse<T, R>>;
 }
+type ExceptEndpoints<T> = T extends MicroCMSTsClient<infer U> ? U : unknown;
+
+export type MicroCMSSchemaInfer<T extends ReturnType<typeof createClient>> = {
+  [K in Parameters<T['getList']>[0]['endpoint']]: MicroCMSGetListDetailResponse<
+    ExceptEndpoints<T>,
+    { endpoint: K; contentId: string }
+  >;
+} & {
+  [K in Parameters<T['getObject']>[0]['endpoint']]: MicroCMSGetObjectResponse<
+    ExceptEndpoints<T>,
+    { endpoint: K }
+  >;
+};


### PR DESCRIPTION
# Added `MicroCMSSchemaInfer` type

```ts
import { createClient, MicroCMSSchemaInfer } from 'microcms-ts-sdk';

// Type definition
type Content = {
  text: string;
};

interface Endpoints {
  // API in list format.
  list: {
    contents: Content;
  };
  // API in object format
  object: {
    content: Content;
  };
}

// Initialize Client SDK.
const client = createClient<Endpoints>({
  serviceDomain: 'YOUR_DOMAIN', // YOUR_DOMAIN is the XXXX part of XXXX.microcms.io
  apiKey: 'YOUR_API_KEY'
});

// Schema type inference
type Schema = MicroCMSSchemaInfer<typeof client>; // Feature
/**
 * Schema[contents]
 * {
 *   id: string;
 *   createdAt: string;
 *   updatedAt: string;
 *   publishedAt?: string;
 *   revisedAt?: string;
 *   text: string;
 * }
 *
 * Schema[content]
 * {
 *   createdAt: string;
 *   updatedAt: string;
 *   publishedAt?: string;
 *   revisedAt?: string;
 *   text: string;
 * }
 */
```