### PR TITLE
Fix incorrect build script

### DIFF
--- a/build.js
+++ b/build.js
@@ -3,7 +3,7 @@ const { build } = require('esbuild');
 const packageJson = require('./package.json');
 
 // @ts-ignore Checked Object keys
-const dependencies = packageJson.hasOwnProperty.call('dependencies')
+const dependencies = hasOwnProperty.call(packageJson, 'dependencies')
   ? packageJson.dependencies
   : {};
 const entryFile = 'src/index.ts';


### PR DESCRIPTION
To reduce the build size, fixed incorrect bundling.

---


## Before

<img width="618" alt="image" src="https://user-images.githubusercontent.com/8979809/234735424-96caf70a-367f-404c-9572-6846932b9622.png">

The bundle size is too large.

## After

<img width="623" alt="image" src="https://user-images.githubusercontent.com/8979809/234735433-26799fc0-1900-4ddf-8867-35925698ccc4.png">


The bundle size, which used to be 47KB, has been reduced to 1KB.  🙌


