### PR TITLE
Add support for picking nested fields in the API response

### DIFF
--- a/sample/used-microcms-ts-client.ts
+++ b/sample/used-microcms-ts-client.ts
@@ -1,7 +1,8 @@
-import { createClient } from '../src';
+import { MicroCMSRelation, createClient } from '../src';
 
 type Content = {
   text: string;
+  related: MicroCMSRelation<Content>[];
 };
 
 type Endpoints = {
@@ -9,7 +10,9 @@ type Endpoints = {
     contents: Content;
   };
   object: {
-    content: Content;
+    pickup: {
+      pickupContents: MicroCMSRelation<Content>[];
+    };
   };
 };
 
@@ -49,7 +52,7 @@ client
 
 client
   .getObject({
-    endpoint: 'content',
+    endpoint: 'pickup',
     queries: {
       fields: ['text', 'publishedAt']
     }
@@ -60,7 +63,8 @@ client
   .create({
     endpoint: 'contents',
     content: {
-      text: 'dummy'
+      text: 'dummy',
+      related: ['xxxxxx']
     }
   })
   .then((res) => res);
@@ -70,7 +74,8 @@ client
     endpoint: 'contents',
     contentId: 'xxxxxx',
     content: {
-      text: 'dummy'
+      text: 'dummy',
+      related: ['xxxxxx']
     }
   })
   .then((res) => res);
@@ -87,9 +92,9 @@ client
 
 client
   .update({
-    endpoint: 'content',
+    endpoint: 'pickup',
     content: {
-      text: 'dummy'
+      pickupContents: ['xxxxxx']
     }
   })
   .then((res) => res);

--- a/src/type-utils.ts
+++ b/src/type-utils.ts
@@ -5,3 +5,27 @@ type NumberToTuple<N extends number, XS extends any[] = []> = Length<XS> extends
   : NumberToTuple<N, [0, ...XS]>;
 
 export type DecrementNum<N extends number> = Length<Cdr<NumberToTuple<N>>>;
+
+type Split<S, Delimiter extends string> = S extends `${infer T}${Delimiter}${infer U}`
+  ? [T, ...Split<U, Delimiter>]
+  : [S];
+
+type DeepPick<T, Keys extends string[]> = Keys extends [infer First, ...infer Rest]
+  ? First extends keyof T
+    ? {
+        [K in First]: T[First] extends any[]
+          ? DeepPick<T[First][number], Extract<Rest, string[]>>[]
+          : DeepPick<T[First], Extract<Rest, string[]>>;
+      }
+    : First extends string
+      ? {
+          [K in First]: DeepPick<unknown, Extract<Rest, string[]>>
+        }
+      : never
+  : T;
+
+type Intersection<T> = (T extends T ? (x: T) => 0 : never) extends (x: infer R) => 0 ? R : never;
+
+export type PickByFields<T, Field> = Intersection<
+  Field extends string ? DeepPick<T, Split<Field, '.'>> : never
+>;


### PR DESCRIPTION
# Support nested fields

```ts
type Content = {
  text: string;
  related: MicroCMSRelation<Content>[];
};

type Endpoints = {
  list: {
    contents: Content;
  };
};

const client = createClient<Endpoints>({
  serviceDomain: 'YOUR_DOMAIN',
  apiKey: 'YOUR_API_KEY'
});

client
  .getListDetail({
    endpoint: 'contents',
    contentId: 'xxx',
    queries: {
      fields: [
        'related.text', // Supported.
        'hoge',         // Allow string. Return type `unkwon`.
        'hoge.piyo',    // Allow string for nested query. Return type `unkwon`.
      ]
    }
  })
  .then((res) => res);
```

Fixed: #125